### PR TITLE
Re-place grid items after changes to column and row definitions

### DIFF
--- a/lib/src/rendering/layout_grid.dart
+++ b/lib/src/rendering/layout_grid.dart
@@ -107,6 +107,7 @@ class RenderLayoutGrid extends RenderBox
     assert(value != null);
     if (_autoPlacementMode == value) return;
     _autoPlacementMode = value;
+    markNeedsPlacement();
     markNeedsLayout();
   }
 
@@ -141,6 +142,7 @@ class RenderLayoutGrid extends RenderBox
   set templateColumnSizes(List<TrackSize> value) {
     if (_templateColumnSizes == value) return;
     _templateColumnSizes = value;
+    markNeedsPlacement();
     markNeedsLayout();
   }
 
@@ -150,6 +152,7 @@ class RenderLayoutGrid extends RenderBox
   set templateRowSizes(List<TrackSize> value) {
     if (_templateRowSizes == value) return;
     _templateRowSizes = value;
+    markNeedsPlacement();
     markNeedsLayout();
   }
 
@@ -279,9 +282,10 @@ class RenderLayoutGrid extends RenderBox
   /// Determines where each grid item is positioned in the grid, using the
   /// auto-placement algorithm if necessary.
   void performItemPlacement() {
-    if (!_needsPlacement) return;
-    _needsPlacement = false;
-    _placementGrid = computeItemPlacement(this);
+    if (_needsPlacement) {
+      _needsPlacement = false;
+      _placementGrid = computeItemPlacement(this);
+    }
   }
 
   /// A rough approximation of

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_layout_grid
 description: A grid-based layout system for Flutter, inspired by CSS Grid Layout
-version: 0.10.0-dev.2
+version: 0.10.1-dev.0
 homepage: https://github.com/madewithfelt/flutter_layout_grid
 
 environment:

--- a/test/placement_utils_test.dart
+++ b/test/placement_utils_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 
 void main() {
   group('template area parsing', () {
-    test('produces correct named GridAreas', () {
+    test('produces correctly named GridAreas', () {
       final templateAreas = gridTemplateAreas([
         'logo     nav      nav      nav',
         'bar      main     main     main',


### PR DESCRIPTION
This was an odd oversight, but I went over all of the inputs to RenderLayoutGrid, and ensured that everything that should affect placement will invalidate appropriately.

Fixes #12!