### PR TITLE
Fix bug in removeDuplicates

### DIFF
--- a/lib/src/rendering/layout_grid.dart
+++ b/lib/src/rendering/layout_grid.dart
@@ -221,7 +221,7 @@ class RenderLayoutGrid extends RenderBox
     return _placementGrid
         .getCellsInTrack(trackIndex, trackType)
         .expand((cell) => cell.occupants)
-        .where(removeDuplicates())
+        .removeDuplicates()
         .toList(growable: false);
   }
 
@@ -412,7 +412,7 @@ class RenderLayoutGrid extends RenderBox
   ) {
     final itemsInIntrinsicTracks = intrinsicTracks
         .expand((t) => getChildrenInTrack(type, t.index))
-        .where(removeDuplicates());
+        .removeDuplicates();
 
     final itemsBySpan = groupBy(itemsInIntrinsicTracks, (RenderObject item) {
       return _placementGrid.itemAreas[item].spanForAxis(sizingAxis);


### PR DESCRIPTION
`removeDuplicates` (now an extension method on `Iterable`, not a top-level) no longer holds states between iterations.

Because it held state previously, every iteration after the first would return no results.

To resolve this issue, a new type of WhereIteratable is introduced that will invokes a predicate building function on every new iteration, so state is only ever limited to a single iteration.

Fixes #20 