### PR TITLE
Grid sizing and overflow

### DIFF
--- a/lib/src/foundation/box.dart
+++ b/lib/src/foundation/box.dart
@@ -2,12 +2,20 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_layout_grid/src/widgets/layout_grid.dart';
 
 extension LayoutGridExtensionsForBoxConstraints on BoxConstraints {
+  /// Returns a new [BoxConstraints] with unbounded (infinite) maximums.
+  BoxConstraints get unbound =>
+      copyWith(maxWidth: double.infinity, maxHeight: double.infinity);
+
   /// Returns a new [BoxConstraints] tightening or loosening the receiver as
   /// specified by [gridFit].
   BoxConstraints constraintsForGridFit(GridFit gridFit) {
     switch (gridFit) {
       case GridFit.expand:
-        return BoxConstraints.tight(biggest);
+        final upperBound = biggest;
+        return BoxConstraints.tightForFinite(
+          width: upperBound.width,
+          height: upperBound.height,
+        );
 
       case GridFit.loose:
         return loosen();

--- a/lib/src/widgets/layout_grid.dart
+++ b/lib/src/widgets/layout_grid.dart
@@ -66,6 +66,10 @@ enum GridFit {
   /// biggest size allowed. For example, if the grid has loose constraints with
   /// a width in the range 10 to 100 and a height in the range 0 to 600, then
   /// the children will be instructed to fill the entire 100×600 size.
+  ///
+  /// If the constraints passed to the grid are unbounded on a dimension, the
+  /// children will be allowed to maximize their sizes on that axis (column
+  /// taking preference).
   expand,
 
   /// The constraints passed to the grid from its parent are loosened. For

--- a/test/grid_fit_test.dart
+++ b/test/grid_fit_test.dart
@@ -57,9 +57,10 @@ void main() {
 
       expect(findGridSizing(tester).gridSize, Size(400, 400));
     });
+  });
 
-    testWidgets('Grids do not overflow, even if their children do',
-        (tester) async {
+  group('Overflowing children', () {
+    testWidgets('do not overflow the grid', (tester) async {
       await tester.pumpWidget(_gridFitHarness(
         constraints: BoxConstraints.tightFor(width: 400, height: 400),
         child: LayoutGrid(
@@ -70,7 +71,30 @@ void main() {
         ),
       ));
 
+      tester.takeException(); // Ignore overflow exception
+
       expect(findGridSizing(tester).gridSize, Size(400, 400));
+    });
+
+    testWidgets('are reported to the user', (tester) async {
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: BoxConstraints.tightFor(width: 400, height: 400),
+        child: LayoutGrid(
+          gridFit: GridFit.expand,
+          templateColumnSizes: [fixed(800)],
+          templateRowSizes: [fixed(800)],
+          children: [Container()],
+        ),
+      ));
+
+      // Ignore overflow exception
+      final dynamic exception = tester.takeException();
+      expect(exception, isFlutterError);
+      expect(exception.diagnostics.first.level, DiagnosticLevel.summary);
+      expect(
+        exception.diagnostics.first.toString(),
+        startsWith('A RenderLayoutGrid overflowed by '),
+      );
     });
   });
 }

--- a/test/grid_fit_test.dart
+++ b/test/grid_fit_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('Grid fit', () {
+    testWidgets('GridFit.loose sizes only as much as it needs to',
+        (tester) async {
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: BoxConstraints.loose(Size(200, 200)),
+        // This grid wants to size to be 100x100, but its parent dictates
+        // otherwise
+        child: LayoutGrid(
+          gridFit: GridFit.loose,
+          templateColumnSizes: [fixed(100)],
+          templateRowSizes: [fixed(100)],
+          children: [],
+        ),
+      ));
+
+      expect(findGridSizing(tester).gridSize, Size(100, 100));
+    });
+
+    testWidgets('GridFit.loose respects minimum constraints', (tester) async {
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: BoxConstraints(minWidth: 200, minHeight: 200),
+        // This grid wants to size to be 100x100, but its parent dictates
+        // otherwise
+        child: LayoutGrid(
+          gridFit: GridFit.loose,
+          templateColumnSizes: [fixed(100)],
+          templateRowSizes: [fixed(100)],
+          children: [],
+        ),
+      ));
+
+      final sizing = findGridSizing(tester);
+      expect(sizing.gridSize, Size(200, 200));
+      expect(sizing.baseSizesForType(TrackType.column), [100]);
+      expect(sizing.baseSizesForType(TrackType.row), [100]);
+    });
+
+    testWidgets('GridFit.expand with bounded constraints sizes to maximum',
+        (tester) async {
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: BoxConstraints.tightFor(width: 400, height: 400),
+        child: LayoutGrid(
+          gridFit: GridFit.expand,
+          templateColumnSizes: [intrinsic()],
+          templateRowSizes: [intrinsic()],
+          children: [],
+        ),
+      ));
+
+      expect(findGridSizing(tester).gridSize, Size(400, 400));
+    });
+
+    testWidgets('Grids do not overflow, even if their children do',
+        (tester) async {
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: BoxConstraints.tightFor(width: 400, height: 400),
+        child: LayoutGrid(
+          gridFit: GridFit.expand,
+          templateColumnSizes: [fixed(800)],
+          templateRowSizes: [fixed(800)],
+          children: [Container()],
+        ),
+      ));
+
+      expect(findGridSizing(tester).gridSize, Size(400, 400));
+    });
+  });
+}
+
+Widget _gridFitHarness({
+  BoxConstraints constraints,
+  @required Widget child,
+}) {
+  if (constraints != null) {
+    child = ConstrainedBox(constraints: constraints, child: child);
+  }
+  return wrapInMinimalApp(UnconstrainedBox(child: child));
+}

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/src/foundation/box.dart';
+import 'package:flutter_layout_grid/src/rendering/layout_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final testConstraints = BoxConstraints.loose(Size(800, 600));
+
+/// Sizes a grid that does not require the Flutter framework (ie, no children)
+/// or widget pumping.
+GridSizingInfo sizeEmptyGrid({
+  GridFit gridFit = GridFit.passthrough,
+  List<TrackSize> columnSizes,
+  List<TrackSize> rowSizes,
+  BoxConstraints constraints,
+}) {
+  final renderGrid = RenderLayoutGrid(
+    gridFit: gridFit,
+    templateColumnSizes: columnSizes,
+    templateRowSizes: rowSizes,
+    textDirection: TextDirection.ltr,
+  );
+  return renderGrid.computeGridSize(
+      (constraints ?? testConstraints).constraintsForGridFit(gridFit));
+}
+
+Future<GridSizingInfo> sizeGridWithChildren(
+  WidgetTester tester, {
+  GridFit gridFit = GridFit.passthrough,
+  List<TrackSize> columnSizes,
+  List<TrackSize> rowSizes,
+  List<Widget> children,
+  BoxConstraints constraints,
+}) async {
+  await tester.pumpWidget(
+    wrapInMinimalApp(
+      ConstrainedBox(
+        constraints: constraints ?? testConstraints,
+        child: LayoutGrid(
+          gridFit: gridFit,
+          templateColumnSizes: columnSizes,
+          templateRowSizes: rowSizes,
+          children: children,
+        ),
+      ),
+    ),
+  );
+
+  final renderGrid =
+      tester.renderObject<RenderLayoutGrid>(find.byType(LayoutGrid));
+  return renderGrid.lastGridSizing;
+}
+
+Widget wrapInMinimalApp(Widget child) {
+  return WidgetsApp(
+    color: Colors.white,
+    builder: (context, child) => child,
+  );
+}
+
+FixedTrackSize fixed(double size) => FixedTrackSize(size);
+FlexibleTrackSize flex(double factor) => FlexibleTrackSize(factor);
+IntrinsicContentTrackSize intrinsic() => IntrinsicContentTrackSize();

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
-import 'package:flutter_layout_grid/src/foundation/box.dart';
 import 'package:flutter_layout_grid/src/rendering/layout_grid.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -21,8 +20,7 @@ GridSizingInfo sizeEmptyGrid({
     templateRowSizes: rowSizes,
     textDirection: TextDirection.ltr,
   );
-  return renderGrid.computeGridSize(
-      (constraints ?? testConstraints).constraintsForGridFit(gridFit));
+  return renderGrid.computeGridSize(constraints ?? testConstraints);
 }
 
 Future<GridSizingInfo> sizeGridWithChildren(
@@ -47,6 +45,10 @@ Future<GridSizingInfo> sizeGridWithChildren(
     ),
   );
 
+  return findGridSizing(tester);
+}
+
+GridSizingInfo findGridSizing(WidgetTester tester) {
   final renderGrid =
       tester.renderObject<RenderLayoutGrid>(find.byType(LayoutGrid));
   return renderGrid.lastGridSizing;
@@ -55,7 +57,7 @@ Future<GridSizingInfo> sizeGridWithChildren(
 Widget wrapInMinimalApp(Widget child) {
   return WidgetsApp(
     color: Colors.white,
-    builder: (context, child) => child,
+    builder: (context, _) => child,
   );
 }
 

--- a/test/track_size_test.dart
+++ b/test/track_size_test.dart
@@ -1,16 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
-import 'package:flutter_layout_grid/src/rendering/layout_grid.dart';
-import 'package:flutter_layout_grid/src/foundation/box.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-final gridKey = GlobalKey();
-final testConstraints = BoxConstraints.loose(Size(800, 600));
+import 'test_helpers.dart';
 
 void main() {
   group('fixed track sizes', () {
     test('are correctly sized', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         columnSizes: [fixed(40), fixed(80)],
         rowSizes: [fixed(20), fixed(30)],
       );
@@ -26,7 +23,7 @@ void main() {
     });
 
     test('do not expand to fill remaining space', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         gridFit: GridFit.expand,
         columnSizes: [fixed(40), fixed(80)],
         rowSizes: [fixed(20), fixed(30)],
@@ -45,7 +42,7 @@ void main() {
 
   group('flexible track sizes', () {
     test('fill remaining space', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         columnSizes: [fixed(100), flex(1)],
         rowSizes: [fixed(100), flex(1)],
       );
@@ -61,7 +58,7 @@ void main() {
     });
 
     test('share space according to their factor (same factor)', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         columnSizes: [fixed(100), flex(1), flex(1)],
         rowSizes: [fixed(100), flex(1), flex(1)],
       );
@@ -77,7 +74,7 @@ void main() {
     });
 
     test('share space according to their factor (varying factors)', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         columnSizes: [fixed(100), flex(1), flex(3)],
         rowSizes: [fixed(100), flex(7), flex(1)],
       );
@@ -93,7 +90,7 @@ void main() {
     });
 
     test('occupy no space if none available', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         columnSizes: [fixed(800), flex(1)],
         rowSizes: [fixed(100)],
         constraints: testConstraints,
@@ -112,7 +109,7 @@ void main() {
 
   group('intrinsic track sizes', () {
     test('stretch to fill the constraint\'s remaining space', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         gridFit: GridFit.expand,
         columnSizes: [fixed(100), intrinsic(), fixed(100)],
         rowSizes: [fixed(100), intrinsic(), fixed(100)],
@@ -129,7 +126,7 @@ void main() {
     });
 
     test('share while stretching to fill remaining space', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         gridFit: GridFit.expand,
         columnSizes: [intrinsic(), intrinsic(), intrinsic(), intrinsic()],
         rowSizes: [intrinsic(), intrinsic(), intrinsic(), intrinsic()],
@@ -146,7 +143,7 @@ void main() {
     });
 
     test('do not stretch if a flexible track is involved', () {
-      final gridSize = _sizeEmptyGrid(
+      final gridSize = sizeEmptyGrid(
         columnSizes: [flex(1), intrinsic()],
         rowSizes: [flex(1), intrinsic()],
       );
@@ -163,7 +160,7 @@ void main() {
 
     testWidgets('sizes to content minimums, then shares what\'s left',
         (tester) async {
-      final gridSize = await _sizeGridWithChildren(
+      final gridSize = await sizeGridWithChildren(
         tester,
         gridFit: GridFit.expand,
         columnSizes: [intrinsic(), intrinsic()],
@@ -187,58 +184,6 @@ void main() {
     });
   });
 }
-
-/// Sizes a grid that does not require the Flutter framework (ie, no children)
-/// or widget pumping.
-GridSizingInfo _sizeEmptyGrid({
-  GridFit gridFit = GridFit.passthrough,
-  List<TrackSize> columnSizes,
-  List<TrackSize> rowSizes,
-  BoxConstraints constraints,
-}) {
-  final renderGrid = RenderLayoutGrid(
-    gridFit: gridFit,
-    templateColumnSizes: columnSizes,
-    templateRowSizes: rowSizes,
-    textDirection: TextDirection.ltr,
-  );
-  return renderGrid.computeGridSize(
-      (constraints ?? testConstraints).constraintsForGridFit(gridFit));
-}
-
-Future<GridSizingInfo> _sizeGridWithChildren(
-  WidgetTester tester, {
-  GridFit gridFit = GridFit.passthrough,
-  List<TrackSize> columnSizes,
-  List<TrackSize> rowSizes,
-  List<Widget> children,
-  BoxConstraints constraints,
-}) async {
-  await tester.pumpWidget(
-    WidgetsApp(
-      color: Colors.white,
-      builder: (context, child) {
-        return ConstrainedBox(
-          constraints: constraints ?? testConstraints,
-          child: LayoutGrid(
-            gridFit: gridFit,
-            templateColumnSizes: columnSizes,
-            templateRowSizes: rowSizes,
-            children: children,
-          ),
-        );
-      },
-    ),
-  );
-
-  final renderGrid =
-      tester.renderObject<RenderLayoutGrid>(find.byType(LayoutGrid));
-  return renderGrid.lastGridSizing;
-}
-
-FixedTrackSize fixed(double size) => FixedTrackSize(size);
-FlexibleTrackSize flex(double factor) => FlexibleTrackSize(factor);
-IntrinsicContentTrackSize intrinsic() => IntrinsicContentTrackSize();
 
 ConstrainedBox constrainedBox(
   double minW,


### PR DESCRIPTION
* Ensures that a grid is always within the constraints provided by its parent
* An unconstrained grid with `GridFit.expand` no longer grows sizes infinitely
* Grids will now draw the overflow stripes when appropriate in debug mode

