### PR TITLE
Introduce a set of track sizing helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ For Flutter versions before v1.14.0, use `flutter_layout_grid: ^0.9.0`
 This is the source for the sample you can see above.
 
 ```dart
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/helpers.dart';
+
 const cellRed = Color(0xffc73232);
 const cellMustard = Color(0xffd7aa22);
 const cellGrey = Color(0xffcfd4e0);
@@ -67,18 +70,14 @@ class Piet extends StatelessWidget {
       child: LayoutGrid(
         columnGap: 12,
         rowGap: 12,
-        templateColumnSizes: [
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(3.5),
-          FlexibleTrackSize(1.3),
-          FlexibleTrackSize(1.3),
-          FlexibleTrackSize(1.3),
-        ],
+        // package:flutter_layout_grid/helpers.dart includes several track
+        // sizing extension methods
+        templateColumnSizes: [1.fr, 3.5.fr, 1.3.fr, 1.3.fr, 1.3.fr],
         templateRowSizes: [
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(0.3),
-          FlexibleTrackSize(1.5),
-          FlexibleTrackSize(1.2),
+          1.0.fr,
+          0.3.fr,
+          1.5.fr,
+          1.2.fr,
         ],
         children: [
           // Column 1

--- a/example/animated_gaps.dart
+++ b/example/animated_gaps.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/helpers.dart';
 
 void main() {
   runApp(MyApp());
@@ -55,16 +56,11 @@ class _AnimatedGapsExampleState extends State<AnimatedGapsExample>
     return LayoutGrid(
       columnGap: gapAnimation.value,
       rowGap: gapAnimation.value,
-      templateColumnSizes: [
-        FlexibleTrackSize(1),
-        FlexibleTrackSize(1),
-        FlexibleTrackSize(1),
-        FlexibleTrackSize(0.75),
-      ],
+      templateColumnSizes: [flex(1), flex(1), flex(1), flex(0.75)],
       templateRowSizes: [
-        FlexibleTrackSize(1),
-        FlexibleTrackSize(1),
-        FlexibleTrackSize(1),
+        flex(1),
+        flex(1),
+        flex(1),
       ],
       children: [
         GridPlacement(

--- a/example/basic.dart
+++ b/example/basic.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/helpers.dart';
 
 void main() {
   runApp(MyApp());
@@ -32,16 +33,11 @@ class LayoutGridExample extends StatelessWidget {
       child: LayoutGrid(
         columnGap: 12,
         rowGap: 12,
-        templateColumnSizes: [
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(0.75),
-        ],
+        templateColumnSizes: [1.fr, 1.fr, 1.fr, 0.75.fr],
         templateRowSizes: [
-          FixedTrackSize(32),
-          FixedTrackSize(32),
-          FixedTrackSize(32),
+          32.px,
+          32.px,
+          32.px,
         ],
         children: [
           GridPlacement(

--- a/example/flutter_layout_grid.dart
+++ b/example/flutter_layout_grid.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/helpers.dart';
 
 void main() {
   runApp(PietApp());
@@ -32,17 +33,17 @@ class Piet extends StatelessWidget {
         columnGap: 12,
         rowGap: 12,
         templateColumnSizes: [
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(3.5),
-          FlexibleTrackSize(1.3),
-          FlexibleTrackSize(1.3),
-          FlexibleTrackSize(1.3),
+          flex(1),
+          flex(3.5),
+          flex(1.3),
+          flex(1.3),
+          flex(1.3)
         ],
         templateRowSizes: [
-          FlexibleTrackSize(1),
-          FlexibleTrackSize(0.3),
-          FlexibleTrackSize(1.5),
-          FlexibleTrackSize(1.2),
+          flex(1),
+          flex(0.3),
+          flex(1.5),
+          flex(1.2),
         ],
         children: [
           // Column 1

--- a/example/periodic_table.dart
+++ b/example/periodic_table.dart
@@ -10,6 +10,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/helpers.dart';
 
 void main() {
   runApp(PeriodicTableApp());
@@ -67,8 +68,8 @@ class _PeriodicTableWidgetState extends State<PeriodicTableWidget> {
   Widget _buildGrid(PeriodicTable table) {
     return LayoutGrid(
       gridFit: GridFit.loose,
-      templateColumnSizes: [FlexibleTrackSize(1)] * table.numColumns,
-      templateRowSizes: [IntrinsicContentTrackSize()] * table.numRows,
+      templateColumnSizes: repeat(table.numColumns, [1.fr]),
+      templateRowSizes: repeat(table.numRows, [auto]),
       columnGap: 0.4.vw,
       rowGap: 0.4.vw,
       children: [

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -1,0 +1,42 @@
+/// Defines a set of helpers functions for building track sizes.
+///
+/// This is in its own package to avoid conflicts.
+library track_size_helpers;
+
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+
+/// An [IntrinsicContentTrackSize], mirroring CSS's name for the track sizing
+/// function.
+const auto = IntrinsicContentTrackSize();
+
+/// Returns a track size that is sized based on its contents.
+IntrinsicContentTrackSize intrinsic({String debugLabel}) =>
+    IntrinsicContentTrackSize(debugLabel: debugLabel);
+
+/// Returns a new track size that is exactly [sizeInPx] wide.
+FixedTrackSize fixed(double sizeInPx, {String debugLabel}) =>
+    FixedTrackSize(sizeInPx, debugLabel: debugLabel);
+
+/// Returns a new track size that expands to fill available space.
+FlexibleTrackSize flex(double flexFactor, {String debugLabel}) =>
+    FlexibleTrackSize(flexFactor, debugLabel: debugLabel);
+
+/// Defines a set of extension methods on [num] for creating tracks
+extension TrackUnitsNumExtension on num {
+  FixedTrackSize get px => fixed(toDouble());
+  FlexibleTrackSize get fr => flex(toDouble());
+}
+
+/// Returns this list repeated [times] times.
+///
+///     repeat(2, [fixed(100), fixed(200)])
+///     // [fixed(100), fixed(200), fixed(100), fixed(200)]
+///
+List<TrackSize> repeat(int times, List<TrackSize> tracks) =>
+    _repeat(times, tracks).toList();
+
+Iterable<T> _repeat<T>(int times, Iterable<T> source) sync* {
+  for (int i = 0; i < times; i++) {
+    yield* source;
+  }
+}


### PR DESCRIPTION
* a constant, `auto`, an intrinsic track size with the same name as the CSS keyword
* a set of functions (with shorter, but possibly colliding names) for creating intrinsic, fixed, and flexible track sizes
* a set of extension methods on num for creating fixed and flexible track sizes, resembling CSS (`100.px`, `1.5.fr`)
* a repeat function, resembling CSS' `repeat()`

All accessible via `import "package:flutter_layout_grid/helpers.dart";`