### PR TITLE
Add support for computeDrySize()

### DIFF
--- a/lib/src/rendering/layout_grid.dart
+++ b/lib/src/rendering/layout_grid.dart
@@ -304,6 +304,12 @@ class RenderLayoutGrid extends RenderBox
     }
   }
 
+  @override
+  @visibleForTesting
+  Size computeDryLayout(BoxConstraints constraints) {
+    return computeGridSize(constraints).gridSize;
+  }
+
   @visibleForTesting
   GridSizingInfo computeGridSize(
     BoxConstraints gridConstraints, {

--- a/test/grid_fit_test.dart
+++ b/test/grid_fit_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_layout_grid/src/rendering/layout_grid.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_helpers.dart';
@@ -95,6 +96,55 @@ void main() {
         exception.diagnostics.first.toString(),
         startsWith('A RenderLayoutGrid overflowed by '),
       );
+    });
+  });
+
+  group('computeDryLayout', () {
+    testWidgets('computes the same size that layout does', (tester) async {
+      final testConstraints = BoxConstraints.tightFor(width: 400, height: 400);
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: testConstraints,
+        child: LayoutGrid(
+          gridFit: GridFit.expand,
+          templateColumnSizes: [1.fr],
+          templateRowSizes: [1.fr],
+          children: [],
+        ),
+      ));
+
+      final renderGrid =
+          tester.renderObject<RenderLayoutGrid>(find.byType(LayoutGrid));
+      expect(
+        renderGrid.lastGridSizing.gridSize,
+        renderGrid.computeDryLayout(testConstraints),
+      );
+    });
+
+    testWidgets('does not call layout() in children', (tester) async {
+      final testConstraints = BoxConstraints.tightFor(width: 400, height: 400);
+
+      // This will layout the child once
+      await tester.pumpWidget(_gridFitHarness(
+        constraints: testConstraints,
+        child: LayoutGrid(
+          gridFit: GridFit.expand,
+          templateColumnSizes: [auto],
+          templateRowSizes: [auto],
+          children: [TestLayoutCountingGridItem()],
+        ),
+      ));
+
+      final renderGrid =
+          tester.renderObject<RenderLayoutGrid>(find.byType(LayoutGrid));
+      final renderGridItem =
+          tester.renderObject<RenderTestLayoutCountingGridItem>(
+              find.byType(TestLayoutCountingGridItem));
+
+      // Ensure the child has been laid out once, then reset the count
+      expect(renderGridItem.layoutCount, 1);
+      renderGridItem.resetCount();
+      renderGrid.computeDryLayout(testConstraints);
+      expect(renderGridItem.layoutCount, 0);
     });
   });
 }

--- a/test/grid_fit_test.dart
+++ b/test/grid_fit_test.dart
@@ -130,15 +130,15 @@ void main() {
           gridFit: GridFit.expand,
           templateColumnSizes: [auto],
           templateRowSizes: [auto],
-          children: [TestLayoutCountingGridItem()],
+          children: [TestLayoutCountingWidget()],
         ),
       ));
 
       final renderGrid =
           tester.renderObject<RenderLayoutGrid>(find.byType(LayoutGrid));
       final renderGridItem =
-          tester.renderObject<RenderTestLayoutCountingGridItem>(
-              find.byType(TestLayoutCountingGridItem));
+          tester.renderObject<RenderTestLayoutCountingWidget>(
+              find.byType(TestLayoutCountingWidget));
 
       // Ensure the child has been laid out once, then reset the count
       expect(renderGridItem.layoutCount, 1);

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -62,13 +62,13 @@ Widget wrapInMinimalApp(Widget child) {
 }
 
 /// A widget whose [RenderObject] counts how many times it has been laid out.
-class TestLayoutCountingGridItem extends LeafRenderObjectWidget {
+class TestLayoutCountingWidget extends LeafRenderObjectWidget {
   @override
   RenderObject createRenderObject(BuildContext context) =>
-      RenderTestLayoutCountingGridItem();
+      RenderTestLayoutCountingWidget();
 }
 
-class RenderTestLayoutCountingGridItem extends RenderBox {
+class RenderTestLayoutCountingWidget extends RenderBox {
   int layoutCount = 0;
 
   void resetCount() => layoutCount = 0;

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -60,3 +60,22 @@ Widget wrapInMinimalApp(Widget child) {
     builder: (context, _) => child,
   );
 }
+
+/// A widget whose [RenderObject] counts how many times it has been laid out.
+class TestLayoutCountingGridItem extends LeafRenderObjectWidget {
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      RenderTestLayoutCountingGridItem();
+}
+
+class RenderTestLayoutCountingGridItem extends RenderBox {
+  int layoutCount = 0;
+
+  void resetCount() => layoutCount = 0;
+
+  @override
+  void performLayout() {
+    layoutCount++;
+    this.size = constraints.biggest;
+  }
+}


### PR DESCRIPTION
computeDrySize() is used to calculate the size of a RenderBox without actually laying it out. Turns out the structure of the RenderLayoutGrid was already well suited to this task, as our sizing calculations are independent from layout.

I also added a couple of tests to make sure that we satisfy the requirements of the function — that the grid's "dry" size is the same as the "wet" size, and that the layout() methods of the grid's children are never called in this instance.'

**NOTE:** Currently in draft, as I have an outstanding question for the Flutter team on whether I'm allowed to be calling `getMinIntrinsicWidth` and its friends on children during a dry layout.

Fixes #42