### PR TITLE
Accessibility example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,12 @@ source, the ordering can be configured via the `Semantics` widgetʼs
 [`sortKey`](https://api.flutter.dev/flutter/semantics/SemanticsSortKey-class.html)
 parameter.
 
+For an example of this in practice, see
+[example/semantic_ordering.dart](example/semantic_ordering.dart).
+
+Automatic semantic ordering is currently being explored in
+[#50](https://github.com/madewithfelt/flutter_layout_grid/issues/50).
+
 ## Differences from CSS Grid Layout
 
 Things in CSS Grid Layout that are not supported:

--- a/example/semantic_ordering.dart
+++ b/example/semantic_ordering.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+
+void main() {
+  runApp(SemanticOrderingApp());
+}
+
+class SemanticOrderingApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      color: Colors.white,
+      builder: (_, __) => SemanticOrdering(),
+    );
+  }
+}
+
+class SemanticOrdering extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      // We need to wrap the entire grid in a Semantics widget, with
+      // `explicitChildNodes: true`, in order for sorting to work properly.
+      explicitChildNodes: true,
+      child: LayoutGrid(
+        areas: '''
+          header
+          content
+          footer
+        ''',
+        columnSizes: [auto],
+        rowSizes: [
+          auto,
+          auto,
+          auto,
+        ],
+        children: [
+          // Using the Semantics widget and its sortKey tells screenreaders to
+          // announce the children in the order you specify, regardless of their
+          // ordering in source code (which is the default).
+          //
+          // In this example, you wouldn't want Footer() to be announced by the
+          // screenreader first, would you? sortKey fixes that.
+          Semantics(sortKey: OrdinalSortKey(3), child: Footer())
+              .inGridArea('footer'),
+          Semantics(sortKey: OrdinalSortKey(1), child: Header())
+              .inGridArea('header'),
+          Semantics(sortKey: OrdinalSortKey(2), child: Content())
+              .inGridArea('content'),
+        ],
+      ),
+    );
+  }
+}
+
+class Header extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Container(
+        color: Colors.red,
+        child: Text('Header'),
+      );
+}
+
+class Content extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Container(
+        color: Colors.grey[300],
+        child: Text('Content'),
+      );
+}
+
+class Footer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => Container(
+        color: Colors.deepPurple,
+        child: Text('Footer'),
+      );
+}

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_layout_grid/flutter_layout_grid.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('accessibility', () {
+    testWidgets('presents children in source order', (tester) async {
+      final gridSemantics = await _pumpAndReturnSemantics(
+        tester,
+        LayoutGrid(
+          columnSizes: [auto],
+          rowSizes: repeat(5, [auto]),
+          children: [
+            Text('this'),
+            Text('is'),
+            Text('in'),
+            Text('source'),
+            Text('order'),
+          ],
+        ),
+      );
+
+      final gridChildLabels = gridSemantics
+          .debugListChildrenInOrder(DebugSemanticsDumpOrder.traversalOrder)
+          .map((node) => node.label);
+      expect(
+        gridChildLabels,
+        ['this', 'is', 'in', 'source', 'order'],
+      );
+    });
+
+    testWidgets('respects ordering provided by Semantics.sortKey',
+        (tester) async {
+      final gridSemantics = await _pumpAndReturnSemantics(
+        tester,
+        LayoutGrid(
+          columnSizes: [auto],
+          rowSizes: repeat(5, [auto]),
+          children: [
+            Semantics(
+              sortKey: OrdinalSortKey(1),
+              child: Text('this'),
+            ),
+            Semantics(
+              sortKey: OrdinalSortKey(3),
+              child: Text('isn\'t'),
+            ),
+            Semantics(
+              sortKey: OrdinalSortKey(2),
+              child: Text('in'),
+            ),
+            Semantics(
+              sortKey: OrdinalSortKey(4),
+              child: Text('source'),
+            ),
+            Semantics(
+              sortKey: OrdinalSortKey(0),
+              child: Text('order'),
+            ),
+          ],
+        ),
+      );
+
+      final gridChildLabels = gridSemantics
+          .debugListChildrenInOrder(DebugSemanticsDumpOrder.traversalOrder)
+          .map((node) => node.label);
+      expect(
+        gridChildLabels,
+        ['order', 'this', 'in', 'isn\'t', 'source'],
+      );
+    });
+  });
+}
+
+Future<SemanticsNode> _pumpAndReturnSemantics(
+    WidgetTester tester, LayoutGrid grid) async {
+  await tester.pumpWidget(wrapInMinimalApp(
+    Semantics(
+      explicitChildNodes: true,
+      child: grid,
+    ),
+  ));
+  return tester.getSemantics(find.byType(LayoutGrid));
+}


### PR DESCRIPTION
Before going 1.0, I wanted to be sure this all worked the way I expected, and add an example for people to file. 

I also filed #50 to improve automatic ordering.